### PR TITLE
Re-enable unsafeSetMemory and UnsafeCopyToArrayCopy transformations

### DIFF
--- a/compiler/compile/OMRCompilation.cpp
+++ b/compiler/compile/OMRCompilation.cpp
@@ -1674,18 +1674,8 @@ bool OMR::Compilation::canTransformUnsafeCopyToArrayCopy()
    {
    if (!self()->getOptions()->realTimeGC() &&
        !TR::Compiler->om.canGenerateArraylets() &&
-       !TR::Compiler->om.isOffHeapAllocationEnabled() &&
        self()->cg()->canTransformUnsafeCopyToArrayCopy())
-      {
-      /* Unsafe.copyMemory(...) and Unsafe.copyMemory0(...) can be called with
-       * offset containing absolute base address and object reference
-       * containing NULL. JIT needs address of the object to get to array data
-       * elements. Location of the data elements is stored in dataAddr slot of
-       * the array header so without object address JIT can't get to those
-       * elements. Hence, disabling the transformation if off-heap is enabled.
-       */
       return true;
-      }
 
    return false;
    }
@@ -1694,23 +1684,8 @@ bool OMR::Compilation::canTransformUnsafeSetMemory()
    {
    if (!self()->getOptions()->realTimeGC() &&
        !TR::Compiler->om.canGenerateArraylets() &&
-       !TR::Compiler->om.isOffHeapAllocationEnabled() &&
        self()->cg()->canTransformUnsafeSetMemory())
-      {
-      /* Object passed into Unsafe.setMemory0(...) is not
-       * guaranteed to be an arrary. Disabling the
-       * transformation until we can figure out a way to
-       * verify object type.
-       * This can be problematic when off heap allocation
-       * is enabled. Off heap technology works
-       * by loading dataAddr pointer from the array header.
-       * Without verifying object type first we might end
-       * up loading some random value and crash.
-       * So disabling the transformation until we figure
-       * out a way to detect arrays.
-       */
       return true;
-      }
 
    return false;
    }

--- a/compiler/x/codegen/OMRCodeGenerator.cpp
+++ b/compiler/x/codegen/OMRCodeGenerator.cpp
@@ -682,19 +682,7 @@ static bool willNotInlineCompareAndSwapNative(TR::Node *node,
    TR::SymbolReference *callSymRef = node->getSymbolReference();
    TR::MethodSymbol *methodSymbol = callSymRef->getSymbol()->castToMethodSymbol();
 
-   /* Disable inlining of compare and swap when off heap
-    * allocation is enabled because compare and swap expects
-    * arrays to be allocated contiguouslly right after the
-    * array header. This is not always the case when off heap
-    * allocation is enabled. We can get around it by reading
-    * the address of the data portion from the array header
-    * but there is not way to tell if the object being
-    * passed in is an array or some other object. So disabling
-    * the transformation until we figure out how to detect
-    * arrays.
-    */
    if (TR::Compiler->om.canGenerateArraylets()
-      && TR::Compiler->om.isOffHeapAllocationEnabled()
       && !node->isUnsafeGetPutCASCallOnNonArray())
       return true;
    static char *disableCASInlining = feGetEnv("TR_DisableCASInlining");


### PR DESCRIPTION
Reverts https://github.com/VermaSh/omr/commit/c5707ddea6189bb14dcb7b74028394ea8ba9b7b7