### PR TITLE
Treat contiguousArrayDataAddrFieldSymbol as Int64

### DIFF
--- a/compiler/compile/OMRSymbolReferenceTable.cpp
+++ b/compiler/compile/OMRSymbolReferenceTable.cpp
@@ -157,7 +157,7 @@ OMR::SymbolReferenceTable::findOrCreateContiguousArrayDataAddrFieldShadowSymRef(
    {
    if (!element(contiguousArrayDataAddrFieldSymbol))
       {
-      TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(), TR::Address);
+      TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(), TR::Int64);
       sym->setContiguousArrayDataAddrFieldSymbol();
       element(contiguousArrayDataAddrFieldSymbol) = new (trHeapMemory()) TR::SymbolReference(self(), contiguousArrayDataAddrFieldSymbol, sym);
       element(contiguousArrayDataAddrFieldSymbol)->setOffset(TR::Compiler->om.offsetOfContiguousDataAddrField());


### PR DESCRIPTION
dataAddr field width is always 64 bit so treating it as TR::Address results in null being loaded from top 32 bits in compressed refs. We need the symbol to be TR::Int64 for it be loaded correctly.